### PR TITLE
get() and count() methods added to file_storage and db_storage

### DIFF
--- a/models/engine/db_storage.py
+++ b/models/engine/db_storage.py
@@ -71,6 +71,16 @@ class DBStorage:
         Session = scoped_session(sess_factory)
         self.__session = Session
 
+    def get(self, cls, id):
+        """A method that retrieves one object: ADDED"""
+        cls_objs = self.all(cls)
+        return cls_objs.get(cls.__name__ + '.' + id)
+    
+    def count(self, cls=None):
+        """This method counts the number of objs in db storage: ADDED"""
+        cls_objs = self.all(cls)
+        return len(cls_objs)
+
     def close(self):
         """call remove() method on the private session attribute"""
         self.__session.remove()

--- a/models/engine/file_storage.py
+++ b/models/engine/file_storage.py
@@ -65,6 +65,16 @@ class FileStorage:
             if key in self.__objects:
                 del self.__objects[key]
 
+    def get(self, cls, id):
+        """A method that retrieves object: ADDED."""
+        cls_objs = self.all(cls)
+        return cls_objs.get(cls.__name__ + '.' + id)
+    
+    def count(self, cls=None):
+        """This method counts the number of objs in storage: ADDED."""
+        cls_objs = self.all(cls)
+        return len(cls_objs)
+
     def close(self):
         """call reload() method for deserializing the JSON file to objects"""
         self.reload()


### PR DESCRIPTION
Description:
This pull request introduces two essential methods, `get()` and `count()`, to enhance the Database Storage functionality. The `get()` method allows users to retrieve objects based on their class and ID, while the `count()` method counts the objects of a specific class, with the option to include all objects when no class is specified.

Type of Change:
- Feature Addition

Details of Changes:
This pull request includes the following changes:

- Added a `get` method to the `FileStorage` and `DBStorage` class, enabling object retrieval by class and ID.
- Added a `count` method to the `FileStorage` and `DBStorage` class for counting objects by class. This method also supports counting all objects when no class is specified.
- Updated unit tests to verify the correctness and functionality of the new methods.
- Updated the project documentation to reflect the introduction of these new methods.

The implementation of `get()` and `count()` methods significantly enhances the capabilities of the Database Storage, enabling more precise data retrieval and object counting.
